### PR TITLE
Bind `this` to `done()` on error

### DIFF
--- a/index.js
+++ b/index.js
@@ -1467,7 +1467,7 @@ Queue.prototype.restore = function (done) {
   this._getAllJobData(function (error, data) {
     //backoff if error throw
     if (error) {
-      done(error);
+      done.bind(this, error);
     }
 
     //restore job schedules


### PR DESCRIPTION
Fixes

```
TypeError: Cannot read property 'emit' of undefined
```

When `restore: true` in the `createQueue()` options object.

This was happening when an error was being passed, as the binding wasn't occuring in that instance.  When I was able to output the error that was occurring, it was:

```
Error: All keys in the pipeline should belong to the same slot
    at Pipeline.exec (/data/node_modules/ioredis/lib/pipeline.js:235:21)
    at Pipeline.pipeline.exec (/data/node_modules/ioredis/lib/transaction.js:34:26)
    at Queue.<anonymous> (/data/node_modules/kue-scheduler/index.js:1428:14)
From previous event:
    at new Pipeline (/data/node_modules/ioredis/lib/pipeline.js:30:18)
    at Cluster.redis.multi (/data/node_modules/ioredis/lib/transaction.js:24:20)
    at Queue.<anonymous> (/data/node_modules/kue-scheduler/index.js:1420:32)
    at runCallback (timers.js:800:20)
    at tryOnImmediate (timers.js:762:5)
    at processImmediate [as _immediateCallback] (timers.js:733:5)
```